### PR TITLE
Bug Fix 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SDH-AudioLoader",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Replaces and adds Steam Deck game UI sounds",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -301,9 +301,10 @@ export default definePlugin((serverApi: ServerAPI) => {
     ),
     icon: <RiFolderMusicFill />,
     onDismount: () => {
+      const { menuMusic } = state.getPublicState();
       if (menuMusic != null) {
         menuMusic.StopPlayback();
-        menuMusic = null;
+        state.setMenuMusic(null);
       }
 
       unpatch(


### PR DESCRIPTION
This fixes the issue where reloading a plugin doesn't kill the old instance of music.

I had this bugfix ready for 1.1.0's release, however I forgot to commit to the branch before launch.