### PR TITLE
1.1.3 Hotfix (Update decky-frontend-lib to 1.7.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SDH-AudioLoader",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Replaces and adds Steam Deck game UI sounds",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",
@@ -39,7 +39,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "decky-frontend-lib": "^1.2.4",
+    "decky-frontend-lib": "1.7.5",
     "framer-motion": "^7.2.0",
     "react-icons": "^4.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@rollup/plugin-typescript': ^8.3.3
   '@types/react': 16.14.0
   '@types/webpack': ^5.28.0
-  decky-frontend-lib: ^1.2.4
+  decky-frontend-lib: 1.7.5
   framer-motion: ^7.2.0
   react-icons: ^4.4.0
   rollup: ^2.77.1
@@ -19,7 +19,7 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  decky-frontend-lib: 1.2.4
+  decky-frontend-lib: 1.7.5
   framer-motion: 7.2.0
   react-icons: 4.4.0
 
@@ -697,8 +697,10 @@ packages:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
     dev: true
 
-  /decky-frontend-lib/1.2.4:
-    resolution: {integrity: sha512-r3mLEey9KUkF68geJVSjNlOz/Fg4vpMKUzoutSceyd8o/J5l+QR+Vf0b3gwK3UN9Sp4Pj4XQ1eB82+/W0ApsFg==}
+  /decky-frontend-lib/1.7.5:
+    resolution: {integrity: sha512-1OX/Ix9W76gF0NJjfm0k/01LYPmC2k/k+k/qqH8JJPlPHh5+W5P8ZG2T8m5wKsqoP7jx2W3k7RNZBh9vAqFoFw==}
+    dependencies:
+      minimist: 1.2.6
     dev: false
 
   /decode-uri-component/0.2.0:
@@ -1070,7 +1072,6 @@ packages:
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
-    dev: true
 
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}


### PR DESCRIPTION
This is to comply with the new requirements set by the decky loader devs to ensure that all plugins are compatible with the new version of webpack used in steamos.