### PR TITLE
Release version 1.2.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ class Pack:
         self.author = json["author"] if ("author" in json) else "Unknown"
         self.require = int(json["manifest_version"]) if ("manifest_version" in json) else 1
         self.ignore = json["ignore"] if ("ignore" in json) else []
-        self.mappings = json["mappings"] if ("mappings" in json) else []
+        self.mappings = json["mappings"] if ("mappings" in json) else {}
         self.music = bool(json["music"]) if ("music" in json) else False
 
         if (AUDIO_LOADER_VERSION < self.require):

--- a/main.py
+++ b/main.py
@@ -128,6 +128,9 @@ class Pack:
         
         self.packPath = packPath
 
+    async def get_loader_version(self) -> int:
+        return AUDIO_LOADER_VERSION
+
     async def delete(self) -> Result:
         try:
             shutil.rmtree(self.packPath)

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ class Result:
 
 class RemoteInstall:
     def __init__(self, plugin):
-        self.packDb = "https://github.com/EMERALD0874/AudioLoader-PackDB/releases/download/1.1.0/packs.json"
+        self.packDb = "https://github.com/EMERALD0874/AudioLoader-PackDB/releases/download/1.2.0/packs.json"
         self.plugin = plugin
         self.packs = []
     

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ starter_config_data = {
 starter_config_string = json.dumps(starter_config_data)
 
 logger = getLogger("AUDIO_LOADER")
-AUDIO_LOADER_VERSION = 1
+AUDIO_LOADER_VERSION = 2
 
 def Log(text : str):
     logger.info(text)
@@ -120,6 +120,7 @@ class Pack:
         self.author = json["author"] if ("author" in json) else "Unknown"
         self.require = int(json["manifest_version"]) if ("manifest_version" in json) else 1
         self.ignore = json["ignore"] if ("ignore" in json) else []
+        self.mappings = json["mappings"] if ("mappings" in json) else []
         self.music = bool(json["music"]) if ("music" in json) else False
 
         if (AUDIO_LOADER_VERSION < self.require):
@@ -142,6 +143,7 @@ class Pack:
             "version": self.version,
             "author": self.author,
             "ignore": self.ignore,
+            "mappings": self.mappings,
             "music": self.music,
             "packPath": self.packPath
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SDH-AudioLoader",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Replaces and adds Steam Deck game UI sounds",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -4,6 +4,7 @@ export class Pack {
   description: string = "";
   path: string = "";
   ignore: string[] = [];
+  mappings: object = {};
   version: string = "v1.0";
   author: string = "";
 
@@ -13,6 +14,7 @@ export class Pack {
     this.description = this.data.description;
     this.path = this.data.packPath.split("/").pop();
     this.ignore = this.data.ignore;
+    this.mappings = this.data.mappings;
     this.version = this.data.version;
     this.author = this.data.author;
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,11 +85,26 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
             newSoundURL = args[0];
             break;
           default:
+            const soundName = args[0].slice(8);
             const currentPack = soundPacks.find((e) => e.name === activeSound);
+            // Ignore check
             if (currentPack?.ignore.includes(args[0].slice(8))) {
               newSoundURL = args[0];
               break;
             }
+            // Mapping check
+            if (Object.keys(currentPack?.mappings || {}).includes(soundName)) {
+              const randIndex = Math.trunc(
+                Math.random() * currentPack?.mappings[soundName].length
+              );
+              const mappedFileName =
+                currentPack?.mappings[soundName][randIndex];
+              newSoundURL = `/sounds_custom/${
+                currentPack?.path || "/error"
+              }/${mappedFileName}`;
+              break;
+            }
+            // Default path-replacing behavior
             newSoundURL = args[0].replace(
               "sounds/",
               `sounds_custom/${currentPack?.path || "/error"}/`
@@ -244,6 +259,8 @@ export default definePlugin((serverApi: ServerAPI) => {
   const state: GlobalState = new GlobalState();
   let menuMusic: any = null;
 
+  // The sound effect intercept/player
+  // Needs to be stored in globalstate in order to unpatch
   const patchInstance = beforePatch(
     AudioParent.GamepadUIAudio.m_AudioPlaybackManager.__proto__,
     "PlayAudioURL",
@@ -257,11 +274,25 @@ export default definePlugin((serverApi: ServerAPI) => {
           newSoundURL = args[0];
           break;
         default:
+          const soundName = args[0].slice(8);
           const currentPack = soundPacks.find((e) => e.name === activeSound);
-          if (currentPack?.ignore.includes(args[0].slice(8))) {
+          // Ignore check
+          if (currentPack?.ignore.includes(soundName)) {
             newSoundURL = args[0];
             break;
           }
+          // Mapping check
+          if (Object.keys(currentPack?.mappings || {}).includes(soundName)) {
+            const randIndex = Math.trunc(
+              Math.random() * currentPack?.mappings[soundName].length
+            );
+            const mappedFileName = currentPack?.mappings[soundName][randIndex];
+            newSoundURL = `/sounds_custom/${
+              currentPack?.path || "/error"
+            }/${mappedFileName}`;
+            break;
+          }
+          // Default path-replacing behavior
           newSoundURL = args[0].replace(
             "sounds/",
             `sounds_custom/${currentPack?.path || "/error"}/`

--- a/src/pack-manager/PackBrowserPage.tsx
+++ b/src/pack-manager/PackBrowserPage.tsx
@@ -6,7 +6,7 @@ import {
   Focusable,
   ButtonItem,
 } from "decky-frontend-lib";
-import { useLayoutEffect, VFC, useMemo, useRef } from "react";
+import { useLayoutEffect, VFC, useMemo, useRef, useState } from "react";
 import { Pack, packDbEntry } from "../classes";
 import * as python from "../python";
 import { useGlobalState } from "../state/GlobalState";
@@ -28,6 +28,12 @@ export const PackBrowserPage: VFC = () => {
     isInstalling,
     setInstalling,
   } = useGlobalState();
+
+  const [backendVersion, setBackendVer] = useState<number>(2);
+  function reloadBackendVer() {
+    python.resolve(python.getBackendVersion(), setBackendVer);
+    console.log(backendVersion);
+  }
 
   async function fetchPackDb() {
     python.resolve(python.fetchPackDb(), (response: any) => {
@@ -55,9 +61,14 @@ export const PackBrowserPage: VFC = () => {
   }
   useLayoutEffect(() => {
     fetchPackDb();
+    reloadBackendVer();
   }, []);
 
   const searchFilter = (e: packDbEntry) => {
+    // This means only compatible themes will show up, newer ones won't
+    if (e.manifest_version > backendVersion) {
+      return false;
+    }
     // This filter just implements the search stuff
     if (searchFieldValue.length > 0) {
       // Convert the theme and search to lowercase so that it's not case-sensitive

--- a/src/pack-manager/PackBrowserPage.tsx
+++ b/src/pack-manager/PackBrowserPage.tsx
@@ -6,7 +6,7 @@ import {
   Focusable,
   ButtonItem,
 } from "decky-frontend-lib";
-import { useEffect, VFC, useMemo, useRef } from "react";
+import { useLayoutEffect, VFC, useMemo, useRef } from "react";
 import { Pack, packDbEntry } from "../classes";
 import * as python from "../python";
 import { useGlobalState } from "../state/GlobalState";
@@ -53,7 +53,7 @@ export const PackBrowserPage: VFC = () => {
     fetchPackDb();
     fetchLocalPacks();
   }
-  useEffect(() => {
+  useLayoutEffect(() => {
     fetchPackDb();
   }, []);
 

--- a/src/python.ts
+++ b/src/python.ts
@@ -30,6 +30,10 @@ export function setServer(s: ServerAPI) {
   server = s;
 }
 
+export async function getBackendVersion(): Promise<any> {
+  return server!.callPluginMethod("get_loader_version", {});
+}
+
 export async function fetchPackDb(): Promise<any> {
   return server!.fetchNoCors(
     "https://github.com/EMERALD0874/AudioLoader-PackDB/releases/download/1.2.0/packs.json",

--- a/src/python.ts
+++ b/src/python.ts
@@ -32,7 +32,7 @@ export function setServer(s: ServerAPI) {
 
 export async function fetchPackDb(): Promise<any> {
   return server!.fetchNoCors(
-    "https://github.com/EMERALD0874/AudioLoader-PackDB/releases/download/1.1.0/packs.json",
+    "https://github.com/EMERALD0874/AudioLoader-PackDB/releases/download/1.2.0/packs.json",
     { method: "GET" }
   );
 }

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -4,7 +4,7 @@ import { Pack, packDbEntry } from "../classes";
 
 interface PublicGlobalState {
   menuMusic: any;
-  musicPatchInstance: any;
+  soundPatchInstance: any;
   gamesRunning: Number[];
   activeSound: string;
   soundPacks: Pack[];
@@ -20,7 +20,7 @@ interface PublicGlobalState {
 
 interface PublicGlobalStateContext extends PublicGlobalState {
   setMenuMusic(value: any): void;
-  setMusicPatchInstance(value: any): void;
+  setSoundPatchInstance(value: any): void;
   setGamesRunning(gameArr: Number[]): void;
   setActiveSound(value: string): void;
   setSoundPacks(packArr: Pack[]): void;
@@ -35,7 +35,7 @@ interface PublicGlobalStateContext extends PublicGlobalState {
 // This class creates the getter and setter functions for all of the global state data.
 export class GlobalState {
   private menuMusic: any = null;
-  private musicPatchInstance: any = null;
+  private soundPatchInstance: any = null;
   private gamesRunning: Number[] = [];
   private activeSound: string = "Default";
   private soundPacks: Pack[] = [];
@@ -55,7 +55,7 @@ export class GlobalState {
   getPublicState() {
     return {
       menuMusic: this.menuMusic,
-      musicPatchInstance: this.musicPatchInstance,
+      soundPatchInstance: this.soundPatchInstance,
       gamesRunning: this.gamesRunning,
       activeSound: this.activeSound,
       soundPacks: this.soundPacks,
@@ -73,8 +73,8 @@ export class GlobalState {
     this.forceUpdate();
   }
 
-  setMusicPatchInstance(value: any) {
-    this.musicPatchInstance = value;
+  setSoundPatchInstance(value: any) {
+    this.soundPatchInstance = value;
     this.forceUpdate();
   }
 
@@ -165,8 +165,8 @@ export const GlobalStateContextProvider: FC<ProviderProps> = ({
   }, []);
 
   const setMenuMusic = (value: any) => globalStateClass.setMenuMusic(value);
-  const setMusicPatchInstance = (value: any) =>
-    globalStateClass.setMusicPatchInstance(value);
+  const setSoundPatchInstance = (value: any) =>
+    globalStateClass.setSoundPatchInstance(value);
   const setGamesRunning = (gameArr: Number[]) =>
     globalStateClass.setGamesRunning(gameArr);
   const setActiveSound = (value: string) =>
@@ -189,7 +189,7 @@ export const GlobalStateContextProvider: FC<ProviderProps> = ({
       value={{
         ...publicState,
         setMenuMusic,
-        setMusicPatchInstance,
+        setSoundPatchInstance,
         setGamesRunning,
         setActiveSound,
         setSoundPacks,


### PR DESCRIPTION
Changelog:

- Mappings
  - If using manifest_version 2, pack creators can now use the `mappings` object 
  - Mappings allow you to "map" a deck sound effect to one (or many) sound files.
  - This allows for sound files that don't have the exact same file name as the sound effect, and for having multiple files per sound effect that are randomly chosen from each time.

- (Re)Added a "Reload Plugin" button in the QAM tab in order to re-fetch local packs and restart all patches/music instances.

- The Pack Browser now filters to only compatible themes for your version of AudioLoader

Important:

DO NOT merge this until the packDb update has been merged and built, as this depends on having packs in the new github release