### PR TITLE
Version 1.3.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ starter_config_data = {
   "selected_pack": "Default",
   "selected_music": "None",
   "sound_volume": 1,
-  "music_volume": 1
+  "music_volume": 0.5
 }
 starter_config_string = json.dumps(starter_config_data)
 
@@ -262,7 +262,7 @@ class Plugin:
             "selected_pack": "Default", 
             "selected_music": "None",
             "sound_volume": 1,
-            "music_volume": 1
+            "music_volume": 0.5
         }
 
         self.remote = RemoteInstall(self)

--- a/main.py
+++ b/main.py
@@ -5,7 +5,9 @@ from logging import getLogger
 
 starter_config_data = {
   "selected_pack": "Default",
-  "selected_music": "None"
+  "selected_music": "None",
+  "sound_volume": 1,
+  "music_volume": 1
 }
 starter_config_string = json.dumps(starter_config_data)
 
@@ -258,7 +260,9 @@ class Plugin:
         self.soundPacks = []
         self.config = {
             "selected_pack": "Default", 
-            "selected_music": "None"
+            "selected_music": "None",
+            "sound_volume": 1,
+            "music_volume": 1
         }
 
         self.remote = RemoteInstall(self)

--- a/main.py
+++ b/main.py
@@ -130,9 +130,6 @@ class Pack:
         
         self.packPath = packPath
 
-    async def get_loader_version(self) -> int:
-        return AUDIO_LOADER_VERSION
-
     async def delete(self) -> Result:
         try:
             shutil.rmtree(self.packPath)
@@ -156,6 +153,9 @@ class Pack:
 class Plugin:
     async def dummy_function(self) -> bool:
         return True
+
+    async def get_loader_version(self) -> int:
+        return AUDIO_LOADER_VERSION
 
     async def get_sound_packs(self) -> list:
         return [x.to_dict() for x in self.soundPacks]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "decky-frontend-lib": "3.7.3",
+    "decky-frontend-lib": "3.7.12",
     "framer-motion": "^7.2.0",
     "react-icons": "^4.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "decky-frontend-lib": "3.3.5",
+    "decky-frontend-lib": "3.5.6",
     "framer-motion": "^7.2.0",
     "react-icons": "^4.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "decky-frontend-lib": "3.5.6",
+    "decky-frontend-lib": "3.7.3",
     "framer-motion": "^7.2.0",
     "react-icons": "^4.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SDH-AudioLoader",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Replaces and adds Steam Deck game UI sounds",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@rollup/plugin-typescript': ^8.3.3
   '@types/react': 16.14.0
   '@types/webpack': ^5.28.0
-  decky-frontend-lib: 3.3.5
+  decky-frontend-lib: 3.5.6
   framer-motion: ^7.2.0
   react-icons: ^4.4.0
   rollup: ^2.77.1
@@ -19,7 +19,7 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  decky-frontend-lib: 3.3.5
+  decky-frontend-lib: 3.5.6
   framer-motion: 7.2.0
   react-icons: 4.4.0
 
@@ -697,8 +697,8 @@ packages:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
     dev: true
 
-  /decky-frontend-lib/3.3.5:
-    resolution: {integrity: sha512-nRguw3EM+1fR77izmOSqE37GcDgdEq43Ucv/nz4wtHINNPAZLS02VNbWT03Uw7jWQ9WgA3Dy+oTcgMZQCeFK9A==}
+  /decky-frontend-lib/3.5.6:
+    resolution: {integrity: sha512-PpB044dIgTD/QHywKYh4DTpNSoK7eD+eWkUnf4JPa9T5Ih0zRsIo+fLeUFrZL58Km21Fy/5gvHSmLvN/fMNwOA==}
     dependencies:
       minimist: 1.2.6
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@rollup/plugin-typescript': ^8.3.3
   '@types/react': 16.14.0
   '@types/webpack': ^5.28.0
-  decky-frontend-lib: 3.7.3
+  decky-frontend-lib: 3.7.12
   framer-motion: ^7.2.0
   react-icons: ^4.4.0
   rollup: ^2.77.1
@@ -19,7 +19,7 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  decky-frontend-lib: 3.7.3
+  decky-frontend-lib: 3.7.12
   framer-motion: 7.2.0
   react-icons: 4.4.0
 
@@ -697,10 +697,8 @@ packages:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
     dev: true
 
-  /decky-frontend-lib/3.7.3:
-    resolution: {integrity: sha512-HFHI19zr3gzOXDBF0DE9W+ZSx+mtjc/XqCYANoVfpMaDX1ITZpk2lMzBGuh9QvtHZ4LygtYEPIWDlrJDs8rGKA==}
-    dependencies:
-      minimist: 1.2.6
+  /decky-frontend-lib/3.7.12:
+    resolution: {integrity: sha512-whDV9zHuEBFj17zKoT51aRcUxLvSzBNu2lc242/EO9aFFP064FVCrJu+r7CxWe0hlQ7sA4FKX1qgCwsZ6H+PZg==}
     dev: false
 
   /decode-uri-component/0.2.0:
@@ -1072,6 +1070,7 @@ packages:
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+    dev: true
 
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@rollup/plugin-typescript': ^8.3.3
   '@types/react': 16.14.0
   '@types/webpack': ^5.28.0
-  decky-frontend-lib: 3.5.6
+  decky-frontend-lib: 3.7.3
   framer-motion: ^7.2.0
   react-icons: ^4.4.0
   rollup: ^2.77.1
@@ -19,7 +19,7 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  decky-frontend-lib: 3.5.6
+  decky-frontend-lib: 3.7.3
   framer-motion: 7.2.0
   react-icons: 4.4.0
 
@@ -697,8 +697,8 @@ packages:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
     dev: true
 
-  /decky-frontend-lib/3.5.6:
-    resolution: {integrity: sha512-PpB044dIgTD/QHywKYh4DTpNSoK7eD+eWkUnf4JPa9T5Ih0zRsIo+fLeUFrZL58Km21Fy/5gvHSmLvN/fMNwOA==}
+  /decky-frontend-lib/3.7.3:
+    resolution: {integrity: sha512-HFHI19zr3gzOXDBF0DE9W+ZSx+mtjc/XqCYANoVfpMaDX1ITZpk2lMzBGuh9QvtHZ4LygtYEPIWDlrJDs8rGKA==}
     dependencies:
       minimist: 1.2.6
     dev: false

--- a/src/components/PackDisplayCard.tsx
+++ b/src/components/PackDisplayCard.tsx
@@ -1,0 +1,220 @@
+import { FC, Ref } from "react";
+import { PanelSectionRow, ButtonItem } from "decky-frontend-lib";
+import { motion } from "framer-motion";
+import { useGlobalState } from "../state/GlobalState";
+import { Pack, packDbEntry } from "../classes";
+
+export const PackDisplayCard: FC<{
+  data: packDbEntry;
+  i: number;
+  installRef: Ref<number>;
+  downloadCallback: (e: packDbEntry, i: number) => void;
+}> = ({ data: e, i, installRef, downloadCallback }) => {
+  const { soundPacks, isInstalling } = useGlobalState();
+  function checkIfPackInstalled(themeObj: packDbEntry) {
+    const filteredArr: Pack[] = soundPacks.filter(
+      (e: Pack) =>
+        e.data.name === themeObj.name && e.data.author === themeObj.author
+    );
+    if (filteredArr.length > 0) {
+      if (filteredArr[0].data.version === themeObj.version) {
+        return "installed";
+      } else {
+        return "outdated";
+      }
+    } else {
+      return "uninstalled";
+    }
+  }
+
+  const installStatus = checkIfPackInstalled(e);
+  return (
+    // The outer 2 most divs are the background darkened/blurred image, and everything inside is the text/image/buttons
+    <>
+      <div
+        className="AudioLoader_PackBrowser_SingleItem_Container1"
+        style={{
+          width: "100%",
+          marginLeft: "10px",
+          marginRight: "10px",
+          marginBottom: "20px",
+        }}
+      >
+        <div
+          className="AudioLoader_PackBrowser_SingleItem_Container2"
+          style={{
+            // Really this could be combined with the above div, its just that in CSSLoader there's 2 here, and I didn't want to merge them because its 1am
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+            height: "100%",
+          }}
+        >
+          <div
+            // I'm still using the format of div-with-a-bg-image, because I think that could make it a bit easier to add icons/text in front if we want
+            className="AudioLoader_PackBrowser_SingleItem_PreviewImageContainer"
+            style={{
+              width: "200px",
+              height: "200px",
+              position: "relative",
+            }}
+          >
+            <div
+              style={{
+                backgroundImage: "url(https://i.imgur.com/nISGpci.png)",
+                position: "absolute",
+                top: "10%",
+                left: "0",
+                width: "80%",
+                height: "80%",
+                backgroundSize: "cover",
+                zIndex: 3,
+                borderRadius: "2px",
+              }}
+            />
+            <div
+              style={{
+                backgroundImage: 'url("' + e.preview_image + '")',
+                backgroundColor: "#21323d",
+                position: "absolute",
+                top: "10%",
+                left: "0",
+                width: "80%",
+                height: "80%",
+                backgroundSize: "cover",
+                zIndex: 2,
+                borderRadius: "2px",
+              }}
+            />
+            <motion.div
+              // @ts-ignore - stupid "ref could be null" things here
+              animate={installRef.current === i ? { rotate: 360 } : {}}
+              exit={{}}
+              transition={{
+                // @ts-ignore
+                repeat: installRef.current === i ? Infinity : 0,
+                // @ts-ignore
+                duration: installRef.current === i ? 1.82 : 0.001,
+                ease: "linear",
+              }}
+              style={{
+                backgroundImage: 'url("https://i.imgur.com/V9t3728.png")',
+                position: "absolute",
+                top: "12.5%",
+                right: "0",
+                width: "75%",
+                height: "75%",
+                backgroundSize: "cover",
+                zIndex: 1,
+                rotate: 0,
+              }}
+            />
+          </div>
+          <div
+            style={{
+              width: "calc(100% - 220px)", // The calc is here so that the text section doesn't expand into the image
+              display: "flex",
+              flexDirection: "column",
+              height: "100%",
+              marginLeft: "1em",
+              justifyContent: "center",
+            }}
+          >
+            <span
+              className="AudioLoader_PackBrowser_SingleItem_ThemeName"
+              style={{
+                fontSize: "1.25em",
+                fontWeight: "bold",
+                // This stuff here truncates it if it's too long (prolly not gonna happen on audioloader, just code from cssloader)
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                width: "90%",
+              }}
+            >
+              {e.name}
+            </span>
+            <span
+              className="AudioLoader_PackBrowser_SingleItem_AuthorText"
+              style={{
+                marginRight: "auto",
+                fontSize: "1em",
+                // The text shadows are leftover from cssloader, you can experiment with removing them if you want
+                textShadow: "rgb(48, 48, 48) 0px 0 10px",
+              }}
+            >
+              {e.author}
+            </span>
+            <span
+              className="AudioLoader_PackBrowser_SingleItem_ThemeTarget"
+              style={{
+                fontSize: "1em",
+                textShadow: "rgb(48, 48, 48) 0px 0 10px",
+              }}
+            >
+              {e.music ? "Music" : "Sound"} | {e.version}
+            </span>
+            <span
+              className="AudioLoader_PackBrowser_SingleItem_DescriptionText"
+              style={{
+                fontSize: "13px",
+                textShadow: "rgb(48, 48, 48) 0px 0 10px",
+                color: "#969696",
+                WebkitLineClamp: "3",
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+                display: "-webkit-box",
+              }}
+            >
+              {e.description ? (
+                e.description
+              ) : (
+                <span>
+                  <i style={{ color: "#666" }}>No description provided.</i>
+                </span>
+              )}
+            </span>
+
+            <div
+              className="AudioLoader_PackBrowser_SingleItem_InstallButtonContainer"
+              style={{
+                marginTop: "1em",
+                width: "245px",
+                overflow: "hidden",
+              }}
+            >
+              <PanelSectionRow>
+                <div
+                  className="AudioLoader_PackBrowser_SingleItem_InstallContainer"
+                  style={{
+                    // This padding here overrides the default padding put on PanelSectionRow's by Valve
+                    // Before this, I was using negative margin to "shrink" the element, but this is a much better solution
+                    paddingTop: "0px",
+                    paddingBottom: "0px",
+                  }}
+                >
+                  <ButtonItem
+                    bottomSeparator="none"
+                    layout="below"
+                    disabled={isInstalling || installStatus === "installed"}
+                    onClick={() => {
+                      downloadCallback(e, i);
+                    }}
+                  >
+                    <span className="AudioLoader_PackBrowser_SingleItem_InstallText">
+                      {installStatus === "outdated"
+                        ? "Update Available"
+                        : installStatus === "uninstalled"
+                        ? "Install"
+                        : "Installed"}
+                    </span>
+                  </ButtonItem>
+                </div>
+              </PanelSectionRow>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/components/PackDisplayCard.tsx
+++ b/src/components/PackDisplayCard.tsx
@@ -61,7 +61,9 @@ export const PackDisplayCard: FC<{
           >
             <div
               style={{
-                backgroundImage: "url(https://i.imgur.com/nISGpci.png)",
+                background: e.music
+                  ? "url(https://i.imgur.com/nISGpci.png)"
+                  : "linear-gradient(150deg, rgba(0, 0, 0, 0) 0%, rgba(118, 118, 118, 0) 0%, rgba(255, 255, 255, 0.2) 32%, rgba(255, 255, 255, 0.2) 35%, rgba(255, 255, 255, 0.2) 38%, rgba(210, 210, 210, 0) 70%, rgba(0, 0, 0, 0) 100%) 0% 0% / cover",
                 position: "absolute",
                 top: "10%",
                 left: "0",
@@ -98,7 +100,9 @@ export const PackDisplayCard: FC<{
                 ease: "linear",
               }}
               style={{
-                backgroundImage: 'url("https://i.imgur.com/V9t3728.png")',
+                backgroundImage: e.music
+                  ? 'url("https://i.imgur.com/V9t3728.png")'
+                  : 'url("https://i.imgur.com/pWm35T0.png")',
                 position: "absolute",
                 top: "12.5%",
                 right: "0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -259,7 +259,7 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
               };
               python.setConfig(configObj);
             }}
-            icon={<FaVolumeUp />}
+            icon={<FaMusic />}
           />
         </PanelSectionRow>
         <PanelSectionRow>
@@ -284,7 +284,7 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
               };
               python.setConfig(configObj);
             }}
-            icon={<FaMusic />}
+            icon={<FaVolumeUp />}
           />
         </PanelSectionRow>
         <PanelSectionRow>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ import {
 import { VFC, useMemo, useEffect, useState } from "react";
 import { RiFolderMusicFill } from "react-icons/ri";
 import { AudioParent } from "./gamepadAudioFinder";
-import { PackBrowserPage, UninstallPage } from "./pack-manager";
+import { PackBrowserPage, UninstallPage, AboutPage } from "./pack-manager";
 import * as python from "./python";
 import {
   GlobalState,
@@ -329,14 +329,19 @@ const PackManagerRouter: VFC = () => {
         }}
         tabs={[
           {
-            title: "Browse Packs",
+            title: "Browse",
             content: <PackBrowserPage />,
             id: "browser",
           },
           {
-            title: "Uninstall Packs",
+            title: "Uninstall",
             content: <UninstallPage />,
             id: "uninstall",
+          },
+          {
+            title: "About",
+            content: <AboutPage />,
+            id: "about",
           },
         ]}
       />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "decky-frontend-lib";
 import { VFC, useMemo, useEffect, useState } from "react";
 import { RiFolderMusicFill } from "react-icons/ri";
+import { FaMusic, FaVolumeUp } from "react-icons/fa";
 import { AudioParent } from "./gamepadAudioFinder";
 import { PackBrowserPage, UninstallPage, AboutPage } from "./pack-manager";
 import * as python from "./python";
@@ -190,7 +191,7 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
       <PanelSection title="Packs">
         <PanelSectionRow>
           <DropdownItem
-            bottomSeparator="standard"
+            bottomSeparator="none"
             label="Sounds"
             menuLabel="Sounds"
             rgOptions={SoundPackDropdownOptions}
@@ -216,7 +217,7 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
         </PanelSectionRow>
         <PanelSectionRow>
           <DropdownItem
-            bottomSeparator="none"
+            bottomSeparator="standard"
             label="Music"
             menuLabel="Music"
             rgOptions={MusicPackDropdownOptions}
@@ -242,7 +243,28 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
       <PanelSection title="Settings">
         <PanelSectionRow>
           <SliderField
-            label="Sound Volume"
+            label={undefined}
+            value={musicVolume}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={(value) => {
+              setMusicVolume(value);
+              menuMusic.volume = value;
+              const configObj = {
+                selected_pack: activeSound,
+                selected_music: selectedMusic,
+                sound_volume: soundVolume,
+                music_volume: value,
+              };
+              python.setConfig(configObj);
+            }}
+            icon={<FaVolumeUp />}
+          />
+        </PanelSectionRow>
+        <PanelSectionRow>
+          <SliderField
+            label={undefined}
             value={soundVolume}
             min={0}
             max={2}
@@ -262,31 +284,12 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
               };
               python.setConfig(configObj);
             }}
-          />
-        </PanelSectionRow>
-        <PanelSectionRow>
-          <SliderField
-            label="Music Volume"
-            value={musicVolume}
-            min={0}
-            max={1}
-            step={0.01}
-            onChange={(value) => {
-              setMusicVolume(value);
-              menuMusic.volume = value;
-              const configObj = {
-                selected_pack: activeSound,
-                selected_music: selectedMusic,
-                sound_volume: soundVolume,
-                music_volume: value,
-              };
-              python.setConfig(configObj);
-            }}
+            icon={<FaMusic />}
           />
         </PanelSectionRow>
         <PanelSectionRow>
           <ButtonItem
-            bottomSeparator="thick"
+            bottomSeparator="none"
             layout="below"
             onClick={() => {
               Router.CloseSideMenus();
@@ -298,6 +301,7 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
         </PanelSectionRow>
         <PanelSectionRow>
           <ButtonItem
+            bottomSeparator="standard"
             layout="below"
             onClick={() => {
               fullReload();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -187,13 +187,19 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
   }
 
   return (
-    <div>
+    <div className="audioloader_QAM">
+      <style>
+        {`
+        .audioloader_QAM div[class^="gamepaddialog_FieldLabel_"] {
+          display: none;
+        }
+        `}
+      </style>
       <PanelSection title="Packs">
         <PanelSectionRow>
           <DropdownItem
             bottomSeparator="none"
-            label="Sounds"
-            menuLabel="Sounds"
+            menuLabel="Sound Pack"
             rgOptions={SoundPackDropdownOptions}
             selectedOption={
               // activeSound now stores a string, this just finds the corresponding option for the label
@@ -216,10 +222,35 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
           />
         </PanelSectionRow>
         <PanelSectionRow>
-          <DropdownItem
+          <SliderField
             bottomSeparator="standard"
-            label="Music"
-            menuLabel="Music"
+            label={undefined}
+            value={soundVolume}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={(value) => {
+              gainNode.gain.setValueAtTime(
+                value,
+                gainNode.context.currentTime + 0.01
+              );
+              // gainNode.gain.value = value;
+              setSoundVolume(value);
+              const configObj = {
+                selected_pack: activeSound,
+                selected_music: selectedMusic,
+                sound_volume: value,
+                music_volume: musicVolume,
+              };
+              python.setConfig(configObj);
+            }}
+            icon={<FaVolumeUp />}
+          />
+        </PanelSectionRow>
+        <PanelSectionRow>
+          <DropdownItem
+            bottomSeparator="none"
+            menuLabel="Music Pack"
             rgOptions={MusicPackDropdownOptions}
             selectedOption={
               MusicPackDropdownOptions.find((e) => e.label === selectedMusic)
@@ -239,10 +270,9 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
             }}
           />
         </PanelSectionRow>
-      </PanelSection>
-      <PanelSection title="Settings">
         <PanelSectionRow>
           <SliderField
+            bottomSeparator="standard"
             label={undefined}
             value={musicVolume}
             min={0}
@@ -262,31 +292,8 @@ const Content: VFC<{ serverAPI: ServerAPI }> = ({}) => {
             icon={<FaMusic />}
           />
         </PanelSectionRow>
-        <PanelSectionRow>
-          <SliderField
-            label={undefined}
-            value={soundVolume}
-            min={0}
-            max={2}
-            step={0.1}
-            onChange={(value) => {
-              gainNode.gain.setValueAtTime(
-                value,
-                gainNode.context.currentTime + 0.01
-              );
-              // gainNode.gain.value = value;
-              setSoundVolume(value);
-              const configObj = {
-                selected_pack: activeSound,
-                selected_music: selectedMusic,
-                sound_volume: value,
-                music_volume: musicVolume,
-              };
-              python.setConfig(configObj);
-            }}
-            icon={<FaVolumeUp />}
-          />
-        </PanelSectionRow>
+      </PanelSection>
+      <PanelSection title="Settings">
         <PanelSectionRow>
           <ButtonItem
             bottomSeparator="none"

--- a/src/pack-manager/AboutPage.tsx
+++ b/src/pack-manager/AboutPage.tsx
@@ -1,0 +1,20 @@
+import { VFC } from "react";
+
+export const AboutPage: VFC = () => {
+  return (
+    <>
+      <h2>About</h2>
+      <p>
+        Audio Loader is a plugin for the Decky Loader that allows users to
+        replace Steam UI sounds and add music when outside of a game. The source
+        code is available on GitHub under the MIT License if you would like to
+        make contributions. https://eme.wtf/audioloader
+      </p>
+      <h2>Creating Packs</h2>
+      <p>
+        If you are interested in creating a music or sound pack for Audio
+        Loader, please consult our guide on GitHub. https://eme.wtf/audioguide
+      </p>
+    </>
+  );
+};

--- a/src/pack-manager/PackBrowserPage.tsx
+++ b/src/pack-manager/PackBrowserPage.tsx
@@ -9,7 +9,7 @@ import {
 import { useLayoutEffect, VFC, useMemo, useRef, useState } from "react";
 import { Pack, packDbEntry } from "../classes";
 import * as python from "../python";
-import { TiRefreshOutline } from "react-icons/ti";
+import { FaSyncAlt } from "react-icons/fa";
 import { useGlobalState } from "../state/GlobalState";
 import "../audiomanager.css";
 import { PackDisplayCard } from "../components/packDisplayCard";
@@ -198,7 +198,9 @@ export const PackBrowserPage: VFC = () => {
               // marginLeft: "auto",
             }}
           >
-            <TiRefreshOutline style={{ transform: "translate(0, 2px)" }} />
+            <FaSyncAlt
+              style={{ transform: "translate(0, 2px)", marginRight: 8 }}
+            />
             <span>Refresh</span>
           </DialogButton>
         </Focusable>

--- a/src/pack-manager/PackBrowserPage.tsx
+++ b/src/pack-manager/PackBrowserPage.tsx
@@ -1,17 +1,18 @@
 import {
   DropdownOption,
   PanelSectionRow,
-  DropdownItem,
+  Dropdown,
   TextField,
   Focusable,
-  ButtonItem,
+  DialogButton,
 } from "decky-frontend-lib";
 import { useLayoutEffect, VFC, useMemo, useRef, useState } from "react";
 import { Pack, packDbEntry } from "../classes";
 import * as python from "../python";
+import { TiRefreshOutline } from "react-icons/ti";
 import { useGlobalState } from "../state/GlobalState";
 import "../audiomanager.css";
-import { motion } from "framer-motion";
+import { PackDisplayCard } from "../components/packDisplayCard";
 
 export const PackBrowserPage: VFC = () => {
   const {
@@ -25,7 +26,6 @@ export const PackBrowserPage: VFC = () => {
     setSort,
     selectedTarget,
     setTarget,
-    isInstalling,
     setInstalling,
   } = useGlobalState();
 
@@ -125,31 +125,84 @@ export const PackBrowserPage: VFC = () => {
 
   const installRef = useRef(-1);
 
+  function downloadCallback(e: packDbEntry, i: number) {
+    setInstalling(true);
+    installRef.current = i;
+    python.resolve(python.downloadPack(e.id), () => {
+      fetchLocalPacks();
+      setInstalling(false);
+      if (installRef.current === i) installRef.current = -1;
+    });
+  }
+
   return (
     <>
       <PanelSectionRow>
-        <DropdownItem
-          label="Sort"
-          rgOptions={sortOptions}
-          strDefaultLabel="Last Updated (Newest)"
-          selectedOption={selectedSort}
-          onChange={(e) => setSort(e.data)}
-        />
-        <DropdownItem
-          label="Filter"
-          rgOptions={targetOptions}
-          strDefaultLabel="All"
-          selectedOption={selectedTarget.data}
-          onChange={(e) => setTarget(e)}
-        />
+        <Focusable style={{ display: "flex", maxWidth: "100%" }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              minWidth: "40%",
+              maxWidth: "40%",
+            }}
+          >
+            <span>Sort</span>
+            <Dropdown
+              menuLabel="Sort"
+              rgOptions={sortOptions}
+              strDefaultLabel="Last Updated (Newest)"
+              selectedOption={selectedSort}
+              onChange={(e) => setSort(e.data)}
+            />
+          </div>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              minWidth: "40%",
+              maxWidth: "40%",
+              marginLeft: "auto",
+            }}
+          >
+            <span>Filter</span>
+            <Dropdown
+              menuLabel="Filter"
+              rgOptions={targetOptions}
+              strDefaultLabel="All"
+              selectedOption={selectedTarget.data}
+              onChange={(e) => setTarget(e)}
+            />
+          </div>
+        </Focusable>
       </PanelSectionRow>
-      <PanelSectionRow>
-        <TextField
-          label="Search"
-          value={searchFieldValue}
-          onChange={(e) => setSearchValue(e.target.value)}
-        />
-      </PanelSectionRow>
+      <div style={{ justifyContent: "center", display: "flex" }}>
+        <Focusable
+          style={{ display: "flex", alignItems: "center", width: "96%" }}
+        >
+          <div style={{ minWidth: "75%", marginRight: "auto" }}>
+            <TextField
+              label="Search"
+              value={searchFieldValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+            />
+          </div>
+          <DialogButton
+            onClick={() => {
+              reloadPacks();
+            }}
+            style={{
+              maxWidth: "20%",
+              height: "50%",
+              // marginRight: "auto",
+              // marginLeft: "auto",
+            }}
+          >
+            <TiRefreshOutline style={{ transform: "translate(0, 2px)" }} />
+            <span>Refresh</span>
+          </DialogButton>
+        </Focusable>
+      </div>
       {/* I wrap everything in a Focusable, because that ensures that the dpad/stick navigation works correctly */}
       <Focusable style={{ display: "flex", flexWrap: "wrap" }}>
         {browserPackList
@@ -192,223 +245,16 @@ export const PackBrowserPage: VFC = () => {
             }
           })
           .map((e: packDbEntry, i) => {
-            const installStatus = checkIfPackInstalled(e);
             return (
-              // The outer 2 most divs are the background darkened/blurred image, and everything inside is the text/image/buttons
-              <>
-                <div
-                  className="AudioLoader_PackBrowser_SingleItem_Container1"
-                  style={{
-                    width: "100%",
-                    marginLeft: "10px",
-                    marginRight: "10px",
-                    marginBottom: "20px",
-                  }}
-                >
-                  <div
-                    className="AudioLoader_PackBrowser_SingleItem_Container2"
-                    style={{
-                      // Really this could be combined with the above div, its just that in CSSLoader there's 2 here, and I didn't want to merge them because its 1am
-                      width: "100%",
-                      display: "flex",
-                      alignItems: "center",
-                      height: "100%",
-                    }}
-                  >
-                    <div
-                      // I'm still using the format of div-with-a-bg-image, because I think that could make it a bit easier to add icons/text in front if we want
-                      className="AudioLoader_PackBrowser_SingleItem_PreviewImageContainer"
-                      style={{
-                        width: "200px",
-                        height: "200px",
-                        position: "relative",
-                      }}
-                    >
-                      <div
-                        style={{
-                          backgroundImage:
-                            "url(https://i.imgur.com/nISGpci.png)",
-                          position: "absolute",
-                          top: "10%",
-                          left: "0",
-                          width: "80%",
-                          height: "80%",
-                          backgroundSize: "cover",
-                          zIndex: 3,
-                          borderRadius: "2px",
-                        }}
-                      />
-                      <div
-                        style={{
-                          backgroundImage: 'url("' + e.preview_image + '")',
-                          backgroundColor: "#21323d",
-                          position: "absolute",
-                          top: "10%",
-                          left: "0",
-                          width: "80%",
-                          height: "80%",
-                          backgroundSize: "cover",
-                          zIndex: 2,
-                          borderRadius: "2px",
-                        }}
-                      />
-                      <motion.div
-                        animate={
-                          installRef.current === i ? { rotate: 360 } : {}
-                        }
-                        exit={{}}
-                        transition={{
-                          repeat: installRef.current === i ? Infinity : 0,
-                          duration: installRef.current === i ? 1.82 : 0.001,
-                          ease: "linear",
-                        }}
-                        style={{
-                          backgroundImage:
-                            'url("https://i.imgur.com/V9t3728.png")',
-                          position: "absolute",
-                          top: "12.5%",
-                          right: "0",
-                          width: "75%",
-                          height: "75%",
-                          backgroundSize: "cover",
-                          zIndex: 1,
-                          rotate: 0,
-                        }}
-                      />
-                    </div>
-                    <div
-                      style={{
-                        width: "calc(100% - 220px)", // The calc is here so that the text section doesn't expand into the image
-                        display: "flex",
-                        flexDirection: "column",
-                        height: "100%",
-                        marginLeft: "1em",
-                        justifyContent: "center",
-                      }}
-                    >
-                      <span
-                        className="AudioLoader_PackBrowser_SingleItem_ThemeName"
-                        style={{
-                          fontSize: "1.25em",
-                          fontWeight: "bold",
-                          // This stuff here truncates it if it's too long (prolly not gonna happen on audioloader, just code from cssloader)
-                          whiteSpace: "nowrap",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          width: "90%",
-                        }}
-                      >
-                        {e.name}
-                      </span>
-                      <span
-                        className="AudioLoader_PackBrowser_SingleItem_AuthorText"
-                        style={{
-                          marginRight: "auto",
-                          fontSize: "1em",
-                          // The text shadows are leftover from cssloader, you can experiment with removing them if you want
-                          textShadow: "rgb(48, 48, 48) 0px 0 10px",
-                        }}
-                      >
-                        {e.author}
-                      </span>
-                      <span
-                        className="AudioLoader_PackBrowser_SingleItem_ThemeTarget"
-                        style={{
-                          fontSize: "1em",
-                          textShadow: "rgb(48, 48, 48) 0px 0 10px",
-                        }}
-                      >
-                        {e.music ? "Music" : "Sound"} | {e.version}
-                      </span>
-                      <span
-                        className="AudioLoader_PackBrowser_SingleItem_DescriptionText"
-                        style={{
-                          fontSize: "13px",
-                          textShadow: "rgb(48, 48, 48) 0px 0 10px",
-                          color: "#969696",
-                          WebkitLineClamp: "3",
-                          WebkitBoxOrient: "vertical",
-                          overflow: "hidden",
-                          display: "-webkit-box",
-                        }}
-                      >
-                        {e.description ? (
-                          e.description
-                        ) : (
-                          <span>
-                            <i style={{ color: "#666" }}>
-                              No description provided.
-                            </i>
-                          </span>
-                        )}
-                      </span>
-
-                      <div
-                        className="AudioLoader_PackBrowser_SingleItem_InstallButtonContainer"
-                        style={{
-                          marginTop: "1em",
-                          width: "245px",
-                          overflow: "hidden",
-                        }}
-                      >
-                        <PanelSectionRow>
-                          <div
-                            className="AudioLoader_PackBrowser_SingleItem_InstallContainer"
-                            style={{
-                              // This padding here overrides the default padding put on PanelSectionRow's by Valve
-                              // Before this, I was using negative margin to "shrink" the element, but this is a much better solution
-                              paddingTop: "0px",
-                              paddingBottom: "0px",
-                            }}
-                          >
-                            <ButtonItem
-                              bottomSeparator="none"
-                              layout="below"
-                              disabled={
-                                isInstalling || installStatus === "installed"
-                              }
-                              onClick={() => {
-                                setInstalling(true);
-                                installRef.current = i;
-                                python.resolve(
-                                  python.downloadPack(e.id),
-                                  () => {
-                                    fetchLocalPacks();
-                                    setInstalling(false);
-                                    if (installRef.current === i)
-                                      installRef.current = -1;
-                                  }
-                                );
-                              }}
-                            >
-                              <span className="AudioLoader_PackBrowser_SingleItem_InstallText">
-                                {installStatus === "outdated"
-                                  ? "Update Available"
-                                  : installStatus === "uninstalled"
-                                  ? "Install"
-                                  : "Installed"}
-                              </span>
-                            </ButtonItem>
-                          </div>
-                        </PanelSectionRow>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </>
+              <PackDisplayCard
+                data={e}
+                i={i}
+                installRef={installRef}
+                downloadCallback={downloadCallback}
+              />
             );
           })}
       </Focusable>
-      <PanelSectionRow>
-        <ButtonItem
-          layout="below"
-          onClick={() => {
-            reloadPacks();
-          }}
-        >
-          Reload Packs
-        </ButtonItem>
-      </PanelSectionRow>
     </>
   );
 };

--- a/src/pack-manager/UninstallPage.tsx
+++ b/src/pack-manager/UninstallPage.tsx
@@ -16,6 +16,8 @@ export const UninstallPage: VFC = () => {
     setSelectedMusic,
     menuMusic,
     setMenuMusic,
+    soundVolume,
+    musicVolume,
   } = useGlobalState();
 
   const [isUninstalling, setUninstalling] = useState(false);
@@ -52,6 +54,8 @@ export const UninstallPage: VFC = () => {
             activeSound === listEntry.data.name ? "Default" : activeSound,
           selected_music:
             selectedMusic === listEntry.data.name ? "None" : activeSound,
+          sound_volume: soundVolume,
+          music_volume: musicVolume,
         };
         python.setConfig(configObj);
       }

--- a/src/pack-manager/index.ts
+++ b/src/pack-manager/index.ts
@@ -1,2 +1,3 @@
+export * from "./AboutPage";
 export * from "./PackBrowserPage";
 export * from "./UninstallPage";

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -7,7 +7,8 @@ interface PublicGlobalState {
   soundPatchInstance: any;
   volumePatchInstance: any;
   gainNode: any;
-  gainValue: any;
+  soundVolume: number;
+  musicVolume: number;
   gamesRunning: Number[];
   activeSound: string;
   soundPacks: Pack[];
@@ -26,7 +27,8 @@ interface PublicGlobalStateContext extends PublicGlobalState {
   setSoundPatchInstance(value: any): void;
   setVolumePatchInstance(value: any): void;
   setGainNode(value: any): void;
-  setGainValue(value: number): void;
+  setSoundVolume(value: number): void;
+  setMusicVolume(value: number): void;
   setGamesRunning(value: Number[]): void;
   setActiveSound(value: string): void;
   setSoundPacks(packArr: Pack[]): void;
@@ -44,7 +46,8 @@ export class GlobalState {
   private soundPatchInstance: any = null;
   private volumePatchInstance: any = null;
   private gainNode: any = null;
-  private gainValue: number = 1;
+  private soundVolume: number = 1;
+  private musicVolume: number = 1;
   private gamesRunning: Number[] = [];
   private activeSound: string = "Default";
   private soundPacks: Pack[] = [];
@@ -67,7 +70,8 @@ export class GlobalState {
       soundPatchInstance: this.soundPatchInstance,
       volumePatchInstance: this.volumePatchInstance,
       gainNode: this.gainNode,
-      gainValue: this.gainValue,
+      soundVolume: this.soundVolume,
+      musicVolume: this.musicVolume,
       gamesRunning: this.gamesRunning,
       activeSound: this.activeSound,
       soundPacks: this.soundPacks,
@@ -100,8 +104,13 @@ export class GlobalState {
     this.forceUpdate();
   }
 
-  setGainValue(value: any) {
-    this.gainValue = value;
+  setSoundVolume(value: any) {
+    this.soundVolume = value;
+    this.forceUpdate();
+  }
+
+  setMusicVolume(value: any) {
+    this.musicVolume = value;
     this.forceUpdate();
   }
 
@@ -197,7 +206,10 @@ export const GlobalStateContextProvider: FC<ProviderProps> = ({
   const setVolumePatchInstance = (value: any) =>
     globalStateClass.setVolumePatchInstance(value);
   const setGainNode = (value: any) => globalStateClass.setGainNode(value);
-  const setGainValue = (value: number) => globalStateClass.setGainValue(value);
+  const setSoundVolume = (value: number) =>
+    globalStateClass.setSoundVolume(value);
+  const setMusicVolume = (value: number) =>
+    globalStateClass.setMusicVolume(value);
   const setGamesRunning = (gameArr: Number[]) =>
     globalStateClass.setGamesRunning(gameArr);
   const setActiveSound = (value: string) =>
@@ -223,7 +235,8 @@ export const GlobalStateContextProvider: FC<ProviderProps> = ({
         setSoundPatchInstance,
         setVolumePatchInstance,
         setGainNode,
-        setGainValue,
+        setSoundVolume,
+        setMusicVolume,
         setGamesRunning,
         setActiveSound,
         setSoundPacks,

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -47,7 +47,7 @@ export class GlobalState {
   private volumePatchInstance: any = null;
   private gainNode: any = null;
   private soundVolume: number = 1;
-  private musicVolume: number = 1;
+  private musicVolume: number = 0.5;
   private gamesRunning: Number[] = [];
   private activeSound: string = "Default";
   private soundPacks: Pack[] = [];

--- a/src/state/GlobalState.tsx
+++ b/src/state/GlobalState.tsx
@@ -5,6 +5,9 @@ import { Pack, packDbEntry } from "../classes";
 interface PublicGlobalState {
   menuMusic: any;
   soundPatchInstance: any;
+  volumePatchInstance: any;
+  gainNode: any;
+  gainValue: any;
   gamesRunning: Number[];
   activeSound: string;
   soundPacks: Pack[];
@@ -21,7 +24,10 @@ interface PublicGlobalState {
 interface PublicGlobalStateContext extends PublicGlobalState {
   setMenuMusic(value: any): void;
   setSoundPatchInstance(value: any): void;
-  setGamesRunning(gameArr: Number[]): void;
+  setVolumePatchInstance(value: any): void;
+  setGainNode(value: any): void;
+  setGainValue(value: number): void;
+  setGamesRunning(value: Number[]): void;
   setActiveSound(value: string): void;
   setSoundPacks(packArr: Pack[]): void;
   setSelectedMusic(value: string): void;
@@ -36,6 +42,9 @@ interface PublicGlobalStateContext extends PublicGlobalState {
 export class GlobalState {
   private menuMusic: any = null;
   private soundPatchInstance: any = null;
+  private volumePatchInstance: any = null;
+  private gainNode: any = null;
+  private gainValue: number = 1;
   private gamesRunning: Number[] = [];
   private activeSound: string = "Default";
   private soundPacks: Pack[] = [];
@@ -56,6 +65,9 @@ export class GlobalState {
     return {
       menuMusic: this.menuMusic,
       soundPatchInstance: this.soundPatchInstance,
+      volumePatchInstance: this.volumePatchInstance,
+      gainNode: this.gainNode,
+      gainValue: this.gainValue,
       gamesRunning: this.gamesRunning,
       activeSound: this.activeSound,
       soundPacks: this.soundPacks,
@@ -75,6 +87,21 @@ export class GlobalState {
 
   setSoundPatchInstance(value: any) {
     this.soundPatchInstance = value;
+    this.forceUpdate();
+  }
+
+  setVolumePatchInstance(value: any) {
+    this.volumePatchInstance = value;
+    this.forceUpdate();
+  }
+
+  setGainNode(value: any) {
+    this.gainNode = value;
+    this.forceUpdate();
+  }
+
+  setGainValue(value: any) {
+    this.gainValue = value;
     this.forceUpdate();
   }
 
@@ -167,6 +194,10 @@ export const GlobalStateContextProvider: FC<ProviderProps> = ({
   const setMenuMusic = (value: any) => globalStateClass.setMenuMusic(value);
   const setSoundPatchInstance = (value: any) =>
     globalStateClass.setSoundPatchInstance(value);
+  const setVolumePatchInstance = (value: any) =>
+    globalStateClass.setVolumePatchInstance(value);
+  const setGainNode = (value: any) => globalStateClass.setGainNode(value);
+  const setGainValue = (value: number) => globalStateClass.setGainValue(value);
   const setGamesRunning = (gameArr: Number[]) =>
     globalStateClass.setGamesRunning(gameArr);
   const setActiveSound = (value: string) =>
@@ -190,6 +221,9 @@ export const GlobalStateContextProvider: FC<ProviderProps> = ({
         ...publicState,
         setMenuMusic,
         setSoundPatchInstance,
+        setVolumePatchInstance,
+        setGainNode,
+        setGainValue,
         setGamesRunning,
         setActiveSound,
         setSoundPacks,


### PR DESCRIPTION
- Volume Sliders!
  - There are now independent volume sliders for UI sounds and Music.
  - These can adjust the volume of both sound elements to your liking.
- UI Overhaul
  - The UI has now been redone, featuring full-width packs, visual differences between music packs and sound packs, and an "About" page featuring credits and support resources.  
    - Additionally, extra care has been put in to ensure the new Tab navigation (and all other features) work on both Stable and Beta SteamOS and decky loader.
- Mappings in music packs.
  - You can now use mappings in music packs to map `menu_music.mp3` to one (or more) sound files of your choosing.
  - This does allow for some randomization of menu music, however the randomization will open happen at bootup or upon reloading the plugin.
    - Additionally, we may reject music packs containing multiple songs from the ThemeDb due to file sizes.
- Music Player Rewrite
  - Music packs are now played through their own JS Audio element instead of from the main Steam UI audio player.
  - This allows for independent volume controls, as well as more flexibility in what we can do with music in the future.
