### PR TITLE
Version 1.4.0 - Beginning of the new API

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ class Result:
 
 class RemoteInstall:
     def __init__(self, plugin):
-        self.packDb = "https://github.com/EMERALD0874/AudioLoader-PackDB/releases/download/1.2.0/packs.json"
+        self.packDb = "https://api.deckthemes.com/themes/legacy/audio"
         self.plugin = plugin
         self.packs = []
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SDH-AudioLoader",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Replaces and adds Steam Deck game UI sounds",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",

--- a/src/pack-manager/AboutPage.tsx
+++ b/src/pack-manager/AboutPage.tsx
@@ -13,7 +13,7 @@ export const AboutPage: VFC = () => {
       <h2>Creating Packs</h2>
       <p>
         If you are interested in creating a music or sound pack for Audio
-        Loader, please consult our guide on GitHub. https://eme.wtf/audioguide
+        Loader, please consult the DeckThemes Docs. https://docs.deckthemes.com
       </p>
     </>
   );

--- a/src/python.ts
+++ b/src/python.ts
@@ -35,10 +35,9 @@ export async function getBackendVersion(): Promise<any> {
 }
 
 export async function fetchPackDb(): Promise<any> {
-  return server!.fetchNoCors(
-    "https://github.com/EMERALD0874/AudioLoader-PackDB/releases/download/1.2.0/packs.json",
-    { method: "GET" }
-  );
+  return server!.fetchNoCors("https://api.deckthemes.com/themes/legacy/audio", {
+    method: "GET",
+  });
 }
 
 // getSoundPacks just fetches the packs already stored in python memory, you need to call this reload function to re-fetch the folder list


### PR DESCRIPTION
The pack-db url has been changed from the github repository to the Deckthemes.com legacy audio endpoint.

This isn't the same account-integration overhaul that CSSLoader received, but it will come soon.