### PR TITLE
Center non-square images in display cards

### DIFF
--- a/src/components/PackDisplayCard.tsx
+++ b/src/components/PackDisplayCard.tsx
@@ -122,6 +122,7 @@ export const PackDisplayCard: FC<{
                 backgroundImage: imageURLCreator(),
                 backgroundColor: "#21323d",
                 position: "absolute",
+                backgroundPosition: "center",
                 top: "10%",
                 left: "0",
                 width: "80%",


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/102569435/227374910-76b51921-a483-4f26-a554-c81d60b5892e.png)

![image](https://user-images.githubusercontent.com/102569435/227374890-ebc869a1-552c-4aa2-b806-60af55fc93c1.png)
little before and after here
