### PR TITLE
Update documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin for the [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loade
 # Overview
 This plugin searches all folders in `/home/deck/homebrew/themes` for a `pack.json` file describing the music or sound pack. Users can install packs from the curated Pack Manager while connected to the internet or by manually adding folders (not recommended).
 
-[Information on how to create, test, and upload a pack can be found here.](https://github.com/EMERALD0874/AudioLoader-PackDB)
+[Information on how to create, test, and upload a pack can be found here.](https://docs.deckthemes.com/#/AudioLoader/README)
 
 # Installation
 1. Install the [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader).


### PR DESCRIPTION
The old submissions repo has been archived and no longer shows a useful README, so point it at the doc hosted on the dockthemes website.