### PR TITLE
Fix deprecated fetch method to re-enable logging in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SDH-AudioLoader",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Replaces and adds Steam Deck game UI sounds",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",

--- a/src/api.ts
+++ b/src/api.ts
@@ -34,11 +34,10 @@ export function logInWithShortToken(
   const setGlobalState = globalState!.setGlobalState.bind(globalState);
   if (shortTokenValue.length === 12) {
     server!
-      .callServerMethod("http_request", {
+        .fetchNoCors(`${apiUrl}/auth/authenticate_token`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        url: `${apiUrl}/auth/authenticate_token`,
-        data: JSON.stringify({ token: shortTokenValue }),
+        body: JSON.stringify({ token: shortTokenValue }),
       })
       .then((deckyRes) => {
         console.log(deckyRes);


### PR DESCRIPTION
Originally we used callServerMethod instead of fetchNoCors due to a bug that made POST requests not work. This got fixed and now callServerMethod is deprecated so we have to switch this over